### PR TITLE
chore: disable daily cron schedule, switch to manual trigger

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,9 @@
 name: Playwright Tests
 
 on:
-  schedule:
-    - cron: '0 16 * * *'   # Runs daily at 9:30 PM IST (16:00 UTC)
+  workflow_dispatch:  # Manual trigger only (schedule disabled)
+  # schedule:
+  #   - cron: '0 16 * * *'   # Runs daily at 9:30 PM IST (16:00 UTC)
 
 permissions:
   contents: write  # Needed for GitHub Pages deployment


### PR DESCRIPTION
## Title: chore: disable daily cron schedule, switch to manual trigger


Base branch: main ← interview

## Summary

Commented out the daily cron schedule (0 16 * * *) in the Playwright GitHub Actions workflow
Replaced with workflow_dispatch so tests only run when manually triggered from GitHub Actions
## Why
The daily scheduled run is no longer needed. Manual triggering gives full control over when tests execute.

## How to re-enable
Uncomment the schedule block in [.github/workflows/playwright.yml](vscode-webview://13utr6bd4l2nru87u8sm0q154ksi5ibn5od1un9amfrmogujig4v/.github/workflows/playwright.yml) and remove or keep workflow_dispatch as needed.